### PR TITLE
Deprecate gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # SqlToCsvStream
 
+## DEPRECATION WARNING 💀
+
+⚠️ **Warning This project is no longer maintained.** ⚠️
+
+Feel free to fork the gem for your own needs.
+
+## About
+
 This is your favorite gem to produce CSV or JSON directly from SQL queries.
 It queries a PostgreSQL with a [`COPY`](https://www.postgresql.org/docs/current/sql-copy.html) statement and streams the result as CSV/JSON directly into a ruby enumerator.
 

--- a/sql_to_csv_stream.gemspec
+++ b/sql_to_csv_stream.gemspec
@@ -48,4 +48,19 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-bitcrowd'
   spec.add_development_dependency 'rubocop-rails'
+
+  spec.post_install_message = <<~MSG
+     ▄▄▄▄▄▄  ▄▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄   ▄▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄
+    █      ██       █       █   ▄  █ █       █       █      █       █       █      █
+    █  ▄    █    ▄▄▄█    ▄  █  █ █ █ █    ▄▄▄█       █  ▄   █▄     ▄█    ▄▄▄█  ▄    █
+    █ █ █   █   █▄▄▄█   █▄█ █   █▄▄█▄█   █▄▄▄█     ▄▄█ █▄█  █ █   █ █   █▄▄▄█ █ █   █
+    █ █▄█   █    ▄▄▄█    ▄▄▄█    ▄▄  █    ▄▄▄█    █  █      █ █   █ █    ▄▄▄█ █▄█   █
+    █       █   █▄▄▄█   █   █   █  █ █   █▄▄▄█    █▄▄█  ▄   █ █   █ █   █▄▄▄█       █
+    █▄▄▄▄▄▄██▄▄▄▄▄▄▄█▄▄▄█   █▄▄▄█  █▄█▄▄▄▄▄▄▄█▄▄▄▄▄▄▄█▄█ █▄▄█ █▄▄▄█ █▄▄▄▄▄▄▄█▄▄▄▄▄▄█
+
+    !!! WARNING !!!
+
+    Unfortunately sql_to_csv_stream is deprecated...
+
+  MSG
 end


### PR DESCRIPTION
This deprecates `sql_to_csv_stream`...

- Add deprecation message to README
- Add (huge) post install message

```
Bundle complete! 82 Gemfile dependencies, 197 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Post-install message from sql_to_csv_stream:
 ▄▄▄▄▄▄  ▄▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄   ▄▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄
█      ██       █       █   ▄  █ █       █       █      █       █       █      █
█  ▄    █    ▄▄▄█    ▄  █  █ █ █ █    ▄▄▄█       █  ▄   █▄     ▄█    ▄▄▄█  ▄    █
█ █ █   █   █▄▄▄█   █▄█ █   █▄▄█▄█   █▄▄▄█     ▄▄█ █▄█  █ █   █ █   █▄▄▄█ █ █   █
█ █▄█   █    ▄▄▄█    ▄▄▄█    ▄▄  █    ▄▄▄█    █  █      █ █   █ █    ▄▄▄█ █▄█   █
█       █   █▄▄▄█   █   █   █  █ █   █▄▄▄█    █▄▄█  ▄   █ █   █ █   █▄▄▄█       █
█▄▄▄▄▄▄██▄▄▄▄▄▄▄█▄▄▄█   █▄▄▄█  █▄█▄▄▄▄▄▄▄█▄▄▄▄▄▄▄█▄█ █▄▄█ █▄▄▄█ █▄▄▄▄▄▄▄█▄▄▄▄▄▄█

!!! WARNING !!!

Unfortunately sql_to_csv_stream is deprecated...
```
